### PR TITLE
stop listener when connection is not available

### DIFF
--- a/nabto_cpp_wrapper/nabto_client_impl.cpp
+++ b/nabto_cpp_wrapper/nabto_client_impl.cpp
@@ -24,6 +24,10 @@ void ConnectionEventsListenerImpl::futureCallback(NabtoClientFuture* future, Nab
             connection->notifyEvent((int)listener->event_);
             listener->listen();
         }
+        else
+        {
+            listener->stopped();
+        }
     } else {
         // no more events
         listener->stopped();


### PR DESCRIPTION
Issue: memory leak when trying to connect to unavailable device

```
==386773== 
==386773== 1,506 (160 direct, 1,346 indirect) bytes in 1 blocks are definitely lost in loss record 914 of 933
==386773==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==386773==    by 0x3B3BD1: __gnu_cxx::new_allocator<std::_Sp_counted_ptr_inplace<nabto::client::ConnectionImpl, std::allocator<nabto::client::ConnectionImpl>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==    by 0x3B1C0E: std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<nabto::client::ConnectionImpl, std::allocator<nabto::client::ConnectionImpl>, (__gnu_cxx::_Lock_policy)2> > >::allocate(std::allocator<std::_Sp_counted_ptr_inplace<nabto::client::ConnectionImpl, std::allocator<nabto::client::ConnectionImpl>, (__gnu_cxx::_Lock_policy)2> >&, unsigned long) (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==    by 0x3AFC11: std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<nabto::client::ConnectionImpl, std::allocator<nabto::client::ConnectionImpl>, (__gnu_cxx::_Lock_policy)2> > > std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<nabto::client::ConnectionImpl, std::allocator<nabto::client::ConnectionImpl>, (__gnu_cxx::_Lock_policy)2> > >(std::allocator<std::_Sp_counted_ptr_inplace<nabto::client::ConnectionImpl, std::allocator<nabto::client::ConnectionImpl>, (__gnu_cxx::_Lock_policy)2> >&) (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==    by 0x3ACD61: std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<nabto::client::ConnectionImpl, std::allocator<nabto::client::ConnectionImpl>, NabtoClient_*&>(nabto::client::ConnectionImpl*&, std::_Sp_alloc_shared_tag<std::allocator<nabto::client::ConnectionImpl> >, NabtoClient_*&) (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==    by 0x3AAA47: std::__shared_ptr<nabto::client::ConnectionImpl, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<nabto::client::ConnectionImpl>, NabtoClient_*&>(std::_Sp_alloc_shared_tag<std::allocator<nabto::client::ConnectionImpl> >, NabtoClient_*&) (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==    by 0x3A96D4: std::shared_ptr<nabto::client::ConnectionImpl>::shared_ptr<std::allocator<nabto::client::ConnectionImpl>, NabtoClient_*&>(std::_Sp_alloc_shared_tag<std::allocator<nabto::client::ConnectionImpl> >, NabtoClient_*&) (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==    by 0x3A7D96: std::shared_ptr<nabto::client::ConnectionImpl> std::allocate_shared<nabto::client::ConnectionImpl, std::allocator<nabto::client::ConnectionImpl>, NabtoClient_*&>(std::allocator<nabto::client::ConnectionImpl> const&, NabtoClient_*&) (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==    by 0x3A5B3D: std::shared_ptr<nabto::client::ConnectionImpl> std::make_shared<nabto::client::ConnectionImpl, NabtoClient_*&>(NabtoClient_*&) (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==    by 0x3A3C32: nabto::client::ContextImpl::createConnection() (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==    by 0x2D678B: createConnection(std::shared_ptr<nabto::client::Context>, Configuration::DeviceInfo) (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==    by 0x2DC196: main (in {{some_workdir}}/nabto-client-edge-tunnel/build/edge_tunnel_client)
==386773==
```

Reproduction:
* have device, e.g. by `./tcp_tunnel_device --demo-init`
* use edge_tunnel_client to pair e.g. `./edge_tunnel_client --pair-local`
* run edge_tunnel_client with memcheck, e.g. `valgrind --tool=memcheck --leak-check=full --show-leak-kinds=definite --show-error-list=yes --read-var-info=yes ./edge_tunnel_client --services`
  *  -> all good
* shutdown tcp_tunnel_device
* retry `valgrind --tool=memcheck --leak-check=full --show-leak-kinds=definite --show-error-list=yes --read-var-info=yes ./edge_tunnel_client --services` 
  * -> memory leak, see above
